### PR TITLE
Add v3 scraper features

### DIFF
--- a/scrapers/conversation_fetcher.py
+++ b/scrapers/conversation_fetcher.py
@@ -1,0 +1,64 @@
+import json
+import time
+import logging
+import hashlib
+from dataclasses import dataclass
+from typing import List, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class FetchFailure:
+    url: str
+    attempts: int
+    last_error: str
+    timestamp: float
+
+class ConversationFetcher:
+    """Fetch conversation content with retries and failure logging."""
+
+    def __init__(self, extractor, max_attempts: int = 3, delay: float = 2.0,
+                 failure_log: str = "outputs/failed_convos.json"):
+        self.extractor = extractor
+        self.max_attempts = max_attempts
+        self.delay = delay
+        self.failure_log = failure_log
+        self.failures: List[FetchFailure] = []
+        self._hashes: set[str] = set()
+
+    def fetch(self, driver, url: str) -> Optional[Dict[str, str]]:
+        """Fetch a conversation with retries."""
+        error = ""
+        for attempt in range(1, self.max_attempts + 1):
+            try:
+                if not self.extractor.enter_conversation(driver, url):
+                    raise RuntimeError("navigation failed")
+
+                data = self.extractor.get_conversation_content(driver)
+                if not data.get("content"):
+                    raise RuntimeError("empty content")
+
+                # Duplicate detection via content hash
+                content_hash = hashlib.sha1(data["content"].encode("utf-8")).hexdigest()
+                if content_hash in self._hashes:
+                    logger.info("Duplicate conversation detected: %s", url)
+                    return None
+                self._hashes.add(content_hash)
+                return data
+            except Exception as e:  # broad catch for robustness
+                error = str(e)
+                logger.warning("Fetch attempt %s for %s failed: %s", attempt, url, error)
+                time.sleep(self.delay)
+        self.failures.append(FetchFailure(url, self.max_attempts, error, time.time()))
+        return None
+
+    def save_failures(self):
+        if not self.failures:
+            return
+        try:
+            entries = [f.__dict__ for f in self.failures]
+            with open(self.failure_log, "w", encoding="utf-8") as f:
+                json.dump(entries, f, indent=2)
+            logger.info("Saved failure log to %s", self.failure_log)
+        except Exception as e:
+            logger.error("Failed to save failure log: %s", e)

--- a/scrapers/cookie_manager.py
+++ b/scrapers/cookie_manager.py
@@ -13,6 +13,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import os
 import pickle
 import logging
+import time
 from typing import Optional
 from pathlib import Path
 
@@ -125,6 +126,17 @@ class CookieManager:
         """
         cookie_path = filepath or self.cookie_file
         return os.path.exists(cookie_path)
+
+    def cookies_fresh(self, max_age_hours: int = 24) -> bool:
+        """Return True if cookie file exists and is younger than max_age_hours."""
+        cookie_path = self.cookie_file
+        try:
+            if not os.path.exists(cookie_path):
+                return False
+            age_hours = (time.time() - os.path.getmtime(cookie_path)) / 3600
+            return age_hours <= max_age_hours
+        except Exception:
+            return False
     
     def delete_cookies(self, filepath: Optional[str] = None) -> bool:
         """

--- a/scrapers/login_handler.py
+++ b/scrapers/login_handler.py
@@ -404,11 +404,13 @@ class LoginHandler:
         # ------------------------------------------------------------------
 
         # 1️⃣  Inject cookies if we have any
-        if cookie_manager.cookie_file_exists():
+        if cookie_manager.cookie_file_exists() and cookie_manager.cookies_fresh():
             logger.info("[Cookies] Loading saved cookies from %s", cookie_manager.cookie_file)
             cookie_manager.load_cookies(driver)
             logger.debug("[Cookies] %s injected; refreshing page…", driver.current_url)
             driver.refresh()
+        elif cookie_manager.cookie_file_exists():
+            logger.info("[Cookies] Stored cookies appear stale; skipping load")
 
         # 2️⃣  Automated login attempt ------------------------------------------------
         if self.username and self.password:


### PR DESCRIPTION
## Summary
- implement `ConversationFetcher` for per-URL retries and failure logs
- extend `ScraperOrchestrator` to parallelize conversation fetches and write summary logs
- add cookie freshness checks and skip stale cookies
- allow caching and filtering in conversation list

## Testing
- `python -m py_compile scrapers/conversation_fetcher.py core/scraper_orchestrator.py scrapers/cookie_manager.py scrapers/login_handler.py scrapers/conversation_list_manager.py`
- `pytest -q` *(fails: ModuleNotFoundError for undetected_chromedriver)*

------
https://chatgpt.com/codex/tasks/task_e_685d3f9fd9f48329973d6f06fe56f164